### PR TITLE
Avoid breakage when using the homepage plugin

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -28,6 +28,21 @@ export default class OpenInNewTabPlugin extends Plugin {
 					sourcePath: string,
 					newLeaf?: boolean,
 					openViewState?: OpenViewState) {
+						
+					// If using the homepage plugin, don't conflict with its behaviour
+					const homepage = this.app.plugins.plugins.homepage;
+
+					if (homepage && homepage.executing) {
+						oldOpenLinkText &&
+						oldOpenLinkText.apply(this, [
+							linkText,
+							sourcePath,
+							newLeaf,
+							openViewState,
+						])
+						return;
+					}	
+						
 					const fileName = linkText.split("#")?.[0];
 
 					// Detect if we're clicking on a link within the same file. This can happen two ways:


### PR DESCRIPTION
I'm the maintainer of the [obsidian-homepage](https://github.com/mirnovov/obsidian-homepage) plugin.  An issue (mirnovov/obsidian-homepage#44) came up recently, and it turns out that your plugin changing `openLinkText` interferes with mine's functionality.

Ideally, I'd implement this change on my end, to avoid placing an unexpected burden on you. Unfortunately, due to the way monkey-patching functions work, it's rather difficult to do so, so I've implemented this functionality in this PR instead. Basically, it detects when Homepage is doing its thing and reverts to the default `openLinkText` behaviour if that's happening.