### PR TITLE
feat: add handling for DailyNoteRibbon, UniqueNoteRibbon, and search results

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "open-in-new-tab",
 	"name": "Open In New Tab",
-	"version": "1.0.9",
+	"version": "1.1.0",
 	"minAppVersion": "0.15.0",
 	"description": "Opens files in new tabs",
 	"author": "Patrick Lee",


### PR DESCRIPTION
Hi, I processed the additional cases.

Unfortunately, I couldn't make it select the tab with the file if it is open. If you have any ideas on how to do this, I would like to implement it